### PR TITLE
Add MQTT input/output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+# build
+FROM golang:1.19-alpine AS build
+WORKDIR /app
+COPY . .
+RUN go mod download
+RUN go build -o dnstap-relay ./dnstap
+
+# deploy
+FROM alpine:3.17
+WORKDIR /
+COPY --from=build /app/dnstap-relay ./
+ENTRYPOINT ["/dnstap-relay"]

--- a/MqttInput.go
+++ b/MqttInput.go
@@ -1,0 +1,60 @@
+package dnstap
+
+import (
+	mqtt "github.com/eclipse/paho.mqtt.golang"
+)
+
+// A MqttInput reads dnstap data via subscriptions from a MQTT broker.
+type MqttInput struct {
+	client mqtt.Client
+	topics []string
+	qos    byte
+	wait   chan bool
+	reader Reader
+	log    Logger
+}
+
+// NewMqttInput creates a MqttInput subscribing to topics from the given broker.
+func NewMqttInput(opts *mqtt.ClientOptions, topics []string, qos byte) (input *MqttInput, err error) {
+	if err != nil {
+		return nil, err
+	}
+	client := mqtt.NewClient(opts)
+	if token := client.Connect(); token.Wait() && token.Error() != nil {
+		return nil, token.Error()
+	}
+	return &MqttInput{
+		client: client,
+		topics: topics,
+		qos:    qos,
+		wait:   make(chan bool),
+		log:    nullLogger{},
+	}, nil
+}
+
+// SetLogger configures a logger for FrameStreamInput read error reporting.
+func (input *MqttInput) SetLogger(logger Logger) {
+	input.log = logger
+}
+
+// ReadInto subscribes to the topics and registers a handler to copy messages
+// received to the output channel.
+//
+// ReadInto satisfies the dnstap Input interface.
+func (input *MqttInput) ReadInto(output chan []byte) {
+	input.client.IsConnected()
+	for _, topic := range input.topics {
+		input.client.Subscribe(topic, input.qos,
+			func(_ mqtt.Client, m mqtt.Message) {
+				output <- m.Payload()
+			},
+		)
+	}
+}
+
+// Wait never returns since ReadInto immediately returns.
+//
+// Wait satisfies the dnstap Input interface.
+func (input *MqttInput) Wait() {
+	select {}
+}

--- a/MqttOutput.go
+++ b/MqttOutput.go
@@ -1,0 +1,69 @@
+package dnstap
+
+import (
+	mqtt "github.com/eclipse/paho.mqtt.golang"
+	"google.golang.org/protobuf/proto"
+)
+
+// MqttOutput implements a dnstap Output that publishes dnstap data to an MQTT broker.
+type MqttOutput struct {
+	outputChannel chan []byte
+	client        mqtt.Client
+	baseTopic     string
+	qos           byte
+	wait          chan bool
+	log           Logger
+}
+
+// NewMqttOutput creates a MqttOutput for publishing dnstap data to an MQTT broker.
+func NewMqttOutput(opts *mqtt.ClientOptions, baseTopic string, qos byte) (o *MqttOutput, err error) {
+	o = new(MqttOutput)
+	o.baseTopic = baseTopic
+	o.qos = qos
+	o.outputChannel = make(chan []byte, outputChannelSize)
+	o.wait = make(chan bool)
+	client := mqtt.NewClient(opts)
+	if token := client.Connect(); token.Wait() && token.Error() != nil {
+		return nil, token.Error()
+	}
+	return
+}
+
+// SetLogger configures a logger for error events in the MqttOutput
+func (o *MqttOutput) SetLogger(logger Logger) {
+	o.log = logger
+}
+
+// GetOutputChannel returns the channel on which the MqttOutput accepts dnstap data.
+//
+// GetOutputChannel satisfies the dnstap Output interface.
+func (o *MqttOutput) GetOutputChannel() chan []byte {
+	return o.outputChannel
+}
+
+// RunOutputLoop receives dnstap data sent on the output channel, unmarshalls it
+// and publishes it to the mqtt broker
+//
+// RunOutputLoop satisfies the dnstap Output interface.
+func (o *MqttOutput) RunOutputLoop() {
+	dt := &Dnstap{}
+	for frame := range o.outputChannel {
+		if err := proto.Unmarshal(frame, dt); err != nil {
+			o.log.Printf("dnstap.MqttOutput: proto.Unmarshal() failed: %s, returning", err)
+			break
+		}
+
+		// publish message
+		o.client.Publish(o.baseTopic+dt.Type.String(), o.qos, false, frame)
+	}
+	close(o.wait)
+}
+
+// Close closes the output channel and returns when all pending data has been
+// written.
+//
+// Close satisfies the dnstap Output interface.
+func (o *MqttOutput) Close() {
+	close(o.outputChannel)
+	<-o.wait
+}

--- a/MqttOutput.go
+++ b/MqttOutput.go
@@ -26,6 +26,7 @@ func NewMqttOutput(opts *mqtt.ClientOptions, baseTopic string, qos byte) (o *Mqt
 	if token := client.Connect(); token.Wait() && token.Error() != nil {
 		return nil, token.Error()
 	}
+	o.client = client
 	return
 }
 

--- a/dnstap/main.go
+++ b/dnstap/main.go
@@ -125,7 +125,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "dnstap: MQTT output error: %v\n", err)
 		os.Exit(1)
 	}
-	if *flagWriteFile != "" || len(tcpOutputs)+len(unixOutputs) == 0 || *flagMqttOutput != "" {
+	if *flagWriteFile != "" || (len(tcpOutputs)+len(unixOutputs) == 0 && *flagMqttOutput == "") {
 		var format dnstap.TextFormatFunc
 
 		switch {
@@ -192,6 +192,7 @@ func main() {
 			fmt.Fprint(os.Stderr, err)
 			os.Exit(1)
 		}
+		opts.AutoReconnect = true
 		i, err := dnstap.NewMqttInput(opts, mqttTopics, byte(*flagMqttQos))
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "dnstap: Failed to connect to broker %s: %v\n", *flagMqttInput, err)
@@ -260,6 +261,7 @@ func addMqttOutput(mo *mirrorOutput, broker string) error {
 	if err != nil {
 		return err
 	}
+	opts.AutoReconnect = true
 	o, err := dnstap.NewMqttOutput(opts, *flagMqttTopicPrefix, byte(*flagMqttQos))
 	if err != nil {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/dnstap/golang-dnstap
+module github.com/chrisohaver/golang-dnstap
 
 go 1.19
 

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,18 @@
 module github.com/dnstap/golang-dnstap
 
+go 1.19
+
 require (
+	github.com/eclipse/paho.mqtt.golang v1.4.2
 	github.com/farsightsec/golang-framestream v0.3.0
 	github.com/miekg/dns v1.1.31
 	google.golang.org/protobuf v1.23.0
+)
+
+require (
+	github.com/gorilla/websocket v1.4.2 // indirect
+	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect
+	golang.org/x/net v0.0.0-20200425230154-ff2c4b7c35a0 // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
+	golang.org/x/sys v0.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/eclipse/paho.mqtt.golang v1.4.2 h1:66wOzfUHSSI1zamx7jR6yMEI5EuHnT1G6rNA5PM12m4=
+github.com/eclipse/paho.mqtt.golang v1.4.2/go.mod h1:JGt0RsEwEX+Xa/agj90YJ9d9DH2b7upDZMK9HRbFvCA=
 github.com/farsightsec/golang-framestream v0.3.0 h1:/spFQHucTle/ZIPkYqrfshQqPe2VQEzesH243TjIwqA=
 github.com/farsightsec/golang-framestream v0.3.0/go.mod h1:eNde4IQyEiA5br02AouhEHCu3p3UzrCdFR4LuQHklMI=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
@@ -9,6 +11,8 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/miekg/dns v1.1.31 h1:sJFOl9BgwbYAWOGEwr61FU28pqsBNdpRBnhGXtO06Oo=
 github.com/miekg/dns v1.1.31/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -17,14 +21,19 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20190923162816-aa69164e4478 h1:l5EDrHhldLYb3ZRHDUhXF7Om7MvYXnkV9/iQNo1lX6g=
 golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
+golang.org/x/net v0.0.0-20200425230154-ff2c4b7c35a0 h1:Jcxah/M+oLZ/R4/z5RzfPzGbPXnVDPkEDtf2JnuxN+U=
+golang.org/x/net v0.0.0-20200425230154-ff2c4b7c35a0/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe h1:6fAMxZRR6sl1Uq8U61gxU+kPTs2tR8uOySCbBP7BN/M=
 golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.3.0 h1:w8ZOecv6NaNa/zC8944JTU3vz4u6Lagfk4RPQxv92NQ=
+golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20191216052735-49a3e744a425/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
Adds MQTT input and output.

Enable MQTT input/output via the following new flags ...
```
  -M string
        write dnstap payloads to MQTT broker
  -P string
        MQTT topic prefix
  -Q int
        MQTT pub/sub qos
  -m string
        read dnstap payloads from MQTT broker
  -s value
        subscribe to MQTT topics
```

TK-138990